### PR TITLE
[원석]한국투자증권 api 사용을 위한 토큰발급 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,12 @@
             <artifactId>mybatis-spring-boot-starter</artifactId>
             <version>3.0.5</version>
         </dependency>
-
+        <!-- 외부 restapi 인증을 위한 oauth client 의존성 추가-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
+        <!-- -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>

--- a/src/main/java/com/monstersinc/stock101/restclient/stock/controller/StockRestClientController.java
+++ b/src/main/java/com/monstersinc/stock101/restclient/stock/controller/StockRestClientController.java
@@ -1,7 +1,10 @@
 package com.monstersinc.stock101.restclient.stock.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.monstersinc.stock101.restclient.stock.model.service.StockRestClientService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -9,9 +12,16 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/")
 public class StockRestClientController {
-    @GetMapping("/api/v1/rest-client/")
-    public Object restClient() {
+    private final StockRestClientService stockRestClientService;
+    @GetMapping("rest-client/getOAuthtoken")
+    public void  getOAuthToken() {
+        stockRestClientService.getOAuthToken();
+    }
+    @GetMapping("rest-client/getstockinfo")
+    public Object getStockInfo() {
+
         return null;
     }
     

--- a/src/main/java/com/monstersinc/stock101/restclient/stock/model/dto/TokenResDto.java
+++ b/src/main/java/com/monstersinc/stock101/restclient/stock/model/dto/TokenResDto.java
@@ -1,0 +1,19 @@
+package com.monstersinc.stock101.restclient.stock.model.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@RequiredArgsConstructor
+public class TokenResDto {
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+        public record TokenRes(String accessToken, String accessTokenTokenExpired, String TokenType, Integer expiresIn) {
+    }
+
+}

--- a/src/main/java/com/monstersinc/stock101/restclient/stock/model/service/StockRestClientService.java
+++ b/src/main/java/com/monstersinc/stock101/restclient/stock/model/service/StockRestClientService.java
@@ -2,4 +2,6 @@ package com.monstersinc.stock101.restclient.stock.model.service;
 
 public interface StockRestClientService {
     public String test();
+
+    public void getOAuthToken();
 }

--- a/src/main/java/com/monstersinc/stock101/restclient/stock/model/service/StockRestClientServiceImpl.java
+++ b/src/main/java/com/monstersinc/stock101/restclient/stock/model/service/StockRestClientServiceImpl.java
@@ -1,14 +1,34 @@
 package com.monstersinc.stock101.restclient.stock.model.service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.monstersinc.stock101.restclient.stock.model.dto.TokenResDto;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class StockRestClientServiceImpl implements StockRestClientService {
+
+    @Value("${apikey.stock-key}")
+    private String stockKey;
+    @Value("${apikey.stock-Secret}")
+    private String stockSecret;
+	private final ObjectMapper objectMapper;
 
     @Override
     public String test(){
@@ -17,4 +37,47 @@ public class StockRestClientServiceImpl implements StockRestClientService {
         Object obj = restTemplate.getForObject("https://jsonplaceholder.typicode.com/posts", Object.class);
     return obj.toString(); 
     }
+
+    @Override
+    public void getOAuthToken() {
+        try {
+            RestTemplateBuilder builder = new RestTemplateBuilder();
+            RestTemplate restTemplate = builder.build();
+            
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+            
+            Map<String, String> requestMap = new HashMap<>();
+            requestMap.put("grant_type", "client_credentials");
+            requestMap.put("appkey", stockKey);
+            requestMap.put("appsecret", stockSecret);
+            
+            String jsonBody = objectMapper.writeValueAsString(requestMap);
+            
+            HttpEntity<String> requestMessage = new HttpEntity<>(jsonBody, httpHeaders);
+            
+            String URL = "https://openapi.koreainvestment.com:9443/oauth2/tokenP";
+            HttpEntity<String> response = restTemplate.exchange(URL, HttpMethod.POST, requestMessage, String.class);
+            
+            objectMapper.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
+            
+            TokenResDto.TokenRes tokenRes = objectMapper.readValue(response.getBody(), TokenResDto.TokenRes.class);
+            
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+            
+            tokenRes.accessToken();
+            tokenRes.accessTokenTokenExpired();
+            tokenRes.TokenType();
+            tokenRes.expiresIn();
+            System.out.println("Access Token: " + tokenRes.accessToken());
+            System.out.println("Token Expiry: " + tokenRes.accessTokenTokenExpired());
+            System.out.println("Token Type: " + tokenRes.TokenType());
+            System.out.println("Expires In: " + tokenRes.expiresIn() + " seconds");
+            System.out.println("Token Retrieved At: " + LocalDateTime.now().format(formatter));
+            System.out.println("Token Valid Until: " + LocalDateTime.now().plusSeconds(tokenRes.expiresIn()).format(formatter) );
+        }
+        catch (Exception e) {
+                e.printStackTrace();    
+    }
+}
 }


### PR DESCRIPTION
## 📌 작업 내용
- 이번 PR에서 한 작업을 간단히 설명해 주세요.
- 한국투자증권 api 사용을 위한 토큰 발급 구현 완료
## 📝 변경 사항 상세
- 주요 변경 사항을 나열합니다.
  - [O] 새로운 API 엔드포인트 추가 (`/api/v1/rest-client/getoauthtoken`)

## ✅ 체크리스트
- [O] 코드 컨벤션을 지켰는가? (네이밍, 들여쓰기, 어노테이션 위치 등)
- [X] 테스트 코드를 작성했는가?
- [O] 빌드 및 테스트가 통과했는가?
- [O] 불필요한 주석/로그를 제거했는가?

## 📷 스크린샷 (선택)
X

## 🤔 리뷰 포인트
 - 한투 restapi 대장정에 첫 발자국