### PR TITLE
[혜원] 종목 별 게시물 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/monstersinc/stock101/common/model/dto/ItemsResponseDto.java
+++ b/src/main/java/com/monstersinc/stock101/common/model/dto/ItemsResponseDto.java
@@ -1,0 +1,29 @@
+package com.monstersinc.stock101.common.model.dto;
+
+
+import com.monstersinc.stock101.common.model.dto.BaseResponseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+@Getter
+@ToString
+public class ItemsResponseDto<T> extends BaseResponseDto<T> {
+    private final int numOfRows;
+
+    private final int totalCount;
+
+    public ItemsResponseDto(HttpStatus status, List<T> items, int totalCount) {
+        super(status, items);
+        this.numOfRows = items.size();
+        this.totalCount = totalCount;
+    }
+
+    // 전체 조회용 헬퍼
+    public static <T> ItemsResponseDto<T> ofAll(HttpStatus status, List<T> items) {
+        return new ItemsResponseDto<>(status, items, items.size());
+    }
+}

--- a/src/main/java/com/monstersinc/stock101/common/model/dto/ItemsResponseDto.java
+++ b/src/main/java/com/monstersinc/stock101/common/model/dto/ItemsResponseDto.java
@@ -1,8 +1,5 @@
 package com.monstersinc.stock101.common.model.dto;
 
-
-import com.monstersinc.stock101.common.model.dto.BaseResponseDto;
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.ToString;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/monstersinc/stock101/community/controller/CommunityController.java
+++ b/src/main/java/com/monstersinc/stock101/community/controller/CommunityController.java
@@ -1,6 +1,9 @@
 package com.monstersinc.stock101.community.controller;
 
 import com.monstersinc.stock101.common.model.dto.BaseResponseDto;
+import com.monstersinc.stock101.common.model.dto.ItemsResponseDto;
+import com.monstersinc.stock101.community.exception.PostException;
+import com.monstersinc.stock101.community.exception.message.ExceptionMessage;
 import com.monstersinc.stock101.community.model.dto.PostRequestDto;
 import com.monstersinc.stock101.community.model.dto.PostResponseDto;
 import com.monstersinc.stock101.community.model.service.CommunityService;
@@ -13,7 +16,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 
 @RestController
@@ -39,5 +45,14 @@ public class CommunityController {
     public ResponseEntity<BaseResponseDto<PostResponseDto>> detail(@PathVariable int postId) {
         PostResponseDto dto = communityService.getPostDetail(postId);
         return ResponseEntity.ok(new BaseResponseDto<>(HttpStatus.OK, dto));
+    }
+
+    // 종목 별 게시물 리스트 조회
+    @GetMapping("/posts")
+    public ResponseEntity<ItemsResponseDto<PostResponseDto>> list(
+            @RequestParam int stockId) {
+
+        List<PostResponseDto> items = communityService.getPostListByStock(stockId);
+        return ResponseEntity.ok(ItemsResponseDto.ofAll(HttpStatus.OK, items));
     }
 }

--- a/src/main/java/com/monstersinc/stock101/community/controller/CommunityController.java
+++ b/src/main/java/com/monstersinc/stock101/community/controller/CommunityController.java
@@ -2,8 +2,6 @@ package com.monstersinc.stock101.community.controller;
 
 import com.monstersinc.stock101.common.model.dto.BaseResponseDto;
 import com.monstersinc.stock101.common.model.dto.ItemsResponseDto;
-import com.monstersinc.stock101.community.exception.PostException;
-import com.monstersinc.stock101.community.exception.message.ExceptionMessage;
 import com.monstersinc.stock101.community.model.dto.PostRequestDto;
 import com.monstersinc.stock101.community.model.dto.PostResponseDto;
 import com.monstersinc.stock101.community.model.service.CommunityService;

--- a/src/main/java/com/monstersinc/stock101/community/model/mapper/CommunityMapper.java
+++ b/src/main/java/com/monstersinc/stock101/community/model/mapper/CommunityMapper.java
@@ -4,10 +4,14 @@ import com.monstersinc.stock101.community.model.vo.Post;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
+
 @Mapper
 public interface CommunityMapper {
     void insertPost(Post post); // XML에서 insertPost는 꼭 useGeneratedKeys="true" keyProperty="postId" 설정!
 
     Post selectPostById(@Param("id") int id);
+
+    List<Post> selectPostsByStockId(@Param("stockId") int stockId);
 }
 

--- a/src/main/java/com/monstersinc/stock101/community/model/service/CommunityService.java
+++ b/src/main/java/com/monstersinc/stock101/community/model/service/CommunityService.java
@@ -3,9 +3,14 @@ package com.monstersinc.stock101.community.model.service;
 import com.monstersinc.stock101.community.model.dto.PostRequestDto;
 import com.monstersinc.stock101.community.model.dto.PostResponseDto;
 
+import java.util.List;
+
 public interface CommunityService {
     int save(PostRequestDto dto);                         // 생성
+
     PostResponseDto getAPost(int postId);             // 생성 직후/목록용
 
     PostResponseDto getPostDetail(int postId);
+
+    List<PostResponseDto> getPostListByStock(int stockId);
 }

--- a/src/main/java/com/monstersinc/stock101/community/model/service/CommunityServiceImpl.java
+++ b/src/main/java/com/monstersinc/stock101/community/model/service/CommunityServiceImpl.java
@@ -5,8 +5,11 @@ import com.monstersinc.stock101.community.model.dto.PostResponseDto;
 import com.monstersinc.stock101.community.model.mapper.CommunityMapper;
 import com.monstersinc.stock101.community.model.vo.Post;
 import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.RowBounds;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -37,5 +40,11 @@ public class CommunityServiceImpl implements CommunityService {
             throw new IllegalArgumentException("Post not found: " + postId);
         }
         return PostResponseDto.of(post);
+    }
+
+    @Override
+    public List<PostResponseDto> getPostListByStock(int stockId) {
+        List<Post> rows = communityMapper.selectPostsByStockId(stockId);
+        return PostResponseDto.of(rows);
     }
 }

--- a/src/main/java/com/monstersinc/stock101/community/model/service/CommunityServiceImpl.java
+++ b/src/main/java/com/monstersinc/stock101/community/model/service/CommunityServiceImpl.java
@@ -5,7 +5,6 @@ import com.monstersinc.stock101.community.model.dto.PostResponseDto;
 import com.monstersinc.stock101.community.model.mapper.CommunityMapper;
 import com.monstersinc.stock101.community.model.vo.Post;
 import lombok.RequiredArgsConstructor;
-import org.apache.ibatis.session.RowBounds;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/resources/mappers/community/community-mapper.xml
+++ b/src/main/resources/mappers/community/community-mapper.xml
@@ -25,17 +25,7 @@
         <result property="userId"   column="user_id" />
     </resultMap>
 
-    <select id="countPostsByStock" resultType="long">
-        SELECT COUNT(*)
-        FROM posts
-        <where>
-            stock_id = #{stockId}
-            AND is_deleted = 0
-        </where>
-    </select>
-
-    <select id="selectPostsByStock"
-            parameterType="map"
+    <select id="selectPostsByStockId"
             resultMap="postResultMap">
         <include refid="selectPostSql" />
         <where>
@@ -43,7 +33,6 @@
             AND is_deleted = 0
         </where>
         ORDER BY created_at DESC
-        <!-- LIMIT/OFFSET은 RowBounds로 처리 -->
     </select>
 
     <select id="selectPostById"


### PR DESCRIPTION
## 📌 작업 내용
- 종목 별 게시물 리스트 조회 기능 구현

## 📝 변경 사항 상세
- ItemsResponseDto 추가

## ✅ 체크리스트
- [✅] 코드 컨벤션을 지켰는가? (네이밍, 들여쓰기, 어노테이션 위치 등)
- [ ] 테스트 코드를 작성했는가?
- [✅] 빌드 및 테스트가 통과했는가?
- [✅] 불필요한 주석/로그를 제거했는가?

## 📷 스크린샷 (선택)
 X

## 🤔 리뷰 포인트
- 종목 별 상세 페이지에서 게시물 리스트를 토스 증권처럼 최신 순으로 무한 스크롤 할 수 있도록 했습니다. 다들 같은 생각이신지 확인 부탁 드립니다.
- 게시물 별 좋아요 수, 댓글 수 기능 추가 예정입니다.
