### PR TITLE
[석현] 홈화면 클릭 수 높은 인기 뉴스 6개 조회

### DIFF
--- a/src/main/java/com/monstersinc/stock101/news/controller/NewsController.java
+++ b/src/main/java/com/monstersinc/stock101/news/controller/NewsController.java
@@ -1,0 +1,33 @@
+package com.monstersinc.stock101.news.controller;
+
+import com.monstersinc.stock101.common.model.dto.ItemsResponseDto;
+import com.monstersinc.stock101.news.model.service.NewsService;
+import com.monstersinc.stock101.news.model.vo.News;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.monstersinc.stock101.stock.model.service.StockService;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/news-service")
+@RequiredArgsConstructor
+public class NewsController {
+    private final NewsService newsService;
+
+    // 홈화면에 들어갈 인기 뉴스 6개 조회
+    @GetMapping("/popular-news")
+    @Cacheable(value = "newsCache", key = "'latestNews'")
+    public ResponseEntity<ItemsResponseDto<News>> get6PopularNews() {
+        List<News>  news = newsService.getPopularNews();
+        return ResponseEntity.ok(ItemsResponseDto.ofAll(HttpStatus.OK, news));
+    }
+}

--- a/src/main/java/com/monstersinc/stock101/news/model/mapper/NewsMapper.java
+++ b/src/main/java/com/monstersinc/stock101/news/model/mapper/NewsMapper.java
@@ -1,0 +1,11 @@
+package com.monstersinc.stock101.news.model.mapper;
+
+import com.monstersinc.stock101.news.model.vo.News;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface NewsMapper {
+    public List<News> selectPopularNews();
+}

--- a/src/main/java/com/monstersinc/stock101/news/model/service/NewsService.java
+++ b/src/main/java/com/monstersinc/stock101/news/model/service/NewsService.java
@@ -1,0 +1,9 @@
+package com.monstersinc.stock101.news.model.service;
+
+import com.monstersinc.stock101.news.model.vo.News;
+
+import java.util.List;
+
+public interface NewsService {
+    List<News> getPopularNews();
+}

--- a/src/main/java/com/monstersinc/stock101/news/model/service/NewsServiceImpl.java
+++ b/src/main/java/com/monstersinc/stock101/news/model/service/NewsServiceImpl.java
@@ -1,0 +1,19 @@
+package com.monstersinc.stock101.news.model.service;
+
+import com.monstersinc.stock101.news.model.mapper.NewsMapper;
+import com.monstersinc.stock101.news.model.vo.News;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NewsServiceImpl implements NewsService {
+    private final NewsMapper newsMapper;
+
+    @Override
+    public List<News> getPopularNews() {
+        return newsMapper.selectPopularNews();
+    }
+}

--- a/src/main/java/com/monstersinc/stock101/news/model/vo/News.java
+++ b/src/main/java/com/monstersinc/stock101/news/model/vo/News.java
@@ -1,0 +1,25 @@
+package com.monstersinc.stock101.news.model.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class News {
+    private Long newsId;
+    private String link;
+    private String title;
+    private String contentSummary;
+    private LocalDateTime publishedAt;
+    private String result;
+    private int clickCount;
+    private Long stockId;
+}

--- a/src/main/resources/mappers/news/news-mapper.xml
+++ b/src/main/resources/mappers/news/news-mapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="com.monstersinc.stock101.news.model.mapper.NewsMapper">
+
+    <!--  뉴스 ResultMap   -->
+    <resultMap id="newsResultMap" type="News">
+        <id     property="newsId"   column="news_id" />
+        <result property="stockId"  column="stock_id" />
+        <result property="title"  column="title" />
+        <result property="contentSummary"  column="content_summary" />
+        <result property="link"  column="link" />
+        <result property="publishedAt"  column="published_at" />
+        <result property="result"  column="result" />
+        <result property="clickCount"  column="click_count" />
+    </resultMap>
+
+    <!-- 클릭수가 가장 많고 최신순의 6개의 뉴스 가져오기 -->
+    <select id="selectPopularNews" resultMap="newsResultMap">
+        SELECT
+            news_id,
+            stock_id,
+            title,
+            content_summary,
+            link,
+            published_at,
+            result,
+            click_count
+        FROM news
+        ORDER BY click_count DESC, published_at DESC
+        LIMIT 6
+    </select>
+</mapper>


### PR DESCRIPTION
(cherry picked from commit 0de03cd4e2149f2fa0c6b39fcf2c1e31fcdd9f1b)

## 📌 작업 내용
- 홈화면에 가져올 뉴스 6개 조회
- click_count DESC, published_at DESC 로 클릭수->최신순으로 가져옴
- limit 6

## 📝 변경 사항 상세
- 주요 변경 사항을 나열합니다.
  - [ ] 새로운 API 엔드포인트 추가 (`/news-service/popular-news`)

## ✅ 체크리스트
- [o] 코드 컨벤션을 지켰는가? (네이밍, 들여쓰기, 어노테이션 위치 등)
- [ ] 테스트 코드를 작성했는가?
- [o] 빌드 및 테스트가 통과했는가?
- [ ] 불필요한 주석/로그를 제거했는가?

## 📷 스크린샷 (선택)
- API 응답 예시 (Postman 캡처 등)
- 로그나 콘솔 출력 캡처

## 🤔 리뷰 포인트
- 컨벤션을 잘 지켰는지, 정상작동하는지
