### PR TITLE
[석현] 다른 유저 예측 조회 개발 및 허용 구문 추가

### DIFF
--- a/src/main/java/com/monstersinc/stock101/config/SecurityConfig.java
+++ b/src/main/java/com/monstersinc/stock101/config/SecurityConfig.java
@@ -48,6 +48,9 @@ public class SecurityConfig {
 
                         // 5) 주식은 조회만 있으므로 공개
                         .requestMatchers(HttpMethod.POST, "/api/v1/stock/**").permitAll()
+
+                        // 6) 다른 사람의 예측은 공개
+                        .requestMatchers(HttpMethod.GET, "/api/v1/prediction/user/{userId}").permitAll()
                         // 나머지 요청은 일단 모두 허용.
                         .anyRequest().permitAll()
                 )

--- a/src/main/java/com/monstersinc/stock101/prediction/controller/PredictionController.java
+++ b/src/main/java/com/monstersinc/stock101/prediction/controller/PredictionController.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -52,7 +53,7 @@ public class PredictionController {
                 .body(new BaseResponseDto<>(HttpStatus.CREATED, saved));
     }
 
-    @GetMapping
+    @GetMapping("/user/me")
     public ResponseEntity<ItemsResponseDto<Prediction>> getByUserId(
             @AuthenticationPrincipal User authenticationUser
     ) {
@@ -61,5 +62,15 @@ public class PredictionController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body( ItemsResponseDto.ofAll(HttpStatus.OK, predictions));
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<ItemsResponseDto<Prediction>> getByUserIdParam(
+            @PathVariable long userId
+    ) {
+        List<Prediction> predictions = predictionService.selectByUserId(userId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ItemsResponseDto.ofAll(HttpStatus.OK, predictions));
     }
 }


### PR DESCRIPTION
## 📌 작업 내용
- /api/v1/prediction/user/{userId} 추가
- /api/v1/prediction/user/me 로 나의 예측조회 엔드포인트 변경
- SecurityConfig 다른 유저 조회 허용 구문 추가

## ✅ 작업 브랜치
- feature/prediction

## 🤔 리뷰 포인트 및 유의사항
- 리뷰어가 중점적으로 봐줬으면 하는 부분을 적어주세요.

## 📷 스크린샷 (선택)
